### PR TITLE
Fix SyntaxWarning in `lnk_def`

### DIFF
--- a/dissect/shellitem/lnk/c_lnk.py
+++ b/dissect/shellitem/lnk/c_lnk.py
@@ -102,7 +102,7 @@ typedef struct VOLUME_ID {
 };
 
 typedef struct NET_NAME {
-    char net_name[];                            // A NULL–terminated string, as defined by the system default code page, which specifies a server share path; for example, "\\server\share".
+    char net_name[];                            // A NULL–terminated string, as defined by the system default code page, which specifies a server share path; for example, "\\\\server\\share".
 };
 
 typedef struct DEVICE_NAME {


### PR DESCRIPTION
This PR fixes a SyntaxWarning by properly escaping a comment inside the `lnk_def` variable.