### PR TITLE
Add stricter Ruff linting

### DIFF
--- a/dissect/shellitem/lnk/__init__.py
+++ b/dissect/shellitem/lnk/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dissect.shellitem.lnk.lnk import Lnk, c_lnk
 
 __all__ = ["Lnk", "c_lnk"]

--- a/dissect/shellitem/lnk/lnk.py
+++ b/dissect/shellitem/lnk/lnk.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from io import BufferedReader, BytesIO
+import typing
+from io import BytesIO
 from struct import unpack
 from typing import Any, BinaryIO
 from uuid import UUID
@@ -17,13 +18,17 @@ from dissect.shellitem.lnk.c_lnk import (
     c_lnk,
 )
 
+if typing.TYPE_CHECKING:
+    from io import BufferedReader
+
 log = logging.getLogger(__name__)
 logging.lastResort = None
 logging.raiseExceptions = False
 
 
 class LnkExtraData:
-    """Class that represents the a LNK file's EXTRA_DATA structure
+    """Class that represents the a LNK file's EXTRA_DATA structure.
+
     This optional structure hold additional optional structures that convey additional information about a link target
 
     Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ select = [
   "SLOT",
   "SIM",
   "TID",
-  "TCH",
+  "TC",
   "PTH",
   "PLC",
   "TRY",
@@ -105,8 +105,25 @@ select = [
   "PERF",
   "FURB",
   "RUF",
+  "D"
 ]
-ignore = ["E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM105", "TRY003"]
+ignore = [
+    "E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM105", "TRY003", "PLC0415",
+    # Ignore some pydocstyle rules for now as they require a larger cleanup
+    "D1",
+    "D205",
+    "D301",
+    "D417",
+    # Seems bugged: https://github.com/astral-sh/ruff/issues/16824
+    "D402",
+]
+future-annotations = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.flake8-type-checking]
+strict = true
 
 [tool.ruff.lint.per-file-ignores]
 "tests/docs/**" = ["INP001"]
@@ -114,6 +131,7 @@ ignore = ["E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM1
 [tool.ruff.lint.isort]
 known-first-party = ["dissect.shellitem"]
 known-third-party = ["dissect"]
+required-imports = ["from __future__ import annotations"]
 
 [tool.setuptools.packages.find]
 include = ["dissect.*"]

--- a/tests/_docs/conf.py
+++ b/tests/_docs/conf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 extensions = [
     "autoapi.extension",
     "sphinx.ext.autodoc",


### PR DESCRIPTION
Add stricter rules (doctstyle) + Add annotations import to ruff isor required imports.

Code change are only related to addition of from future import annotations + one dot in a documentation string. Regarding few change, I suggest to not add this commit to git blame ignore file.


* fixes #43 